### PR TITLE
[FEAT]  달력 구현

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-08-01T07:52:28.317260Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-08-02T03:29:47.904150Z" />
   </component>
 </project>

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/AccountBookNavHost.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/AccountBookNavHost.kt
@@ -39,7 +39,7 @@ fun AccountBookNavHost(
         }
 
         composable(Calendar.route) {
-            CalendarScreen()
+            CalendarScreen(historyViewModel)
         }
 
         composable(Statistic.route) {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
@@ -1,11 +1,15 @@
 package com.example.android_accountbook_13.presenter.calendar
 
+import android.annotation.SuppressLint
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.GridCells
 import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -17,6 +21,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -28,13 +34,16 @@ import com.example.android_accountbook_13.presenter.history.HistoryViewModel
 import com.example.android_accountbook_13.ui.theme.*
 import com.example.android_accountbook_13.utils.*
 
+@SuppressLint("StateFlowValueCalledInComposition")
+@RequiresApi(Build.VERSION_CODES.N)
 @Composable
 fun CalendarScreen(
     historyViewModel: HistoryViewModel
 ) {
+    historyViewModel.getAccountBookItems()
+    historyViewModel.getCheckedItems(true,true)
     var date by historyViewModel.date
     var isDialog by rememberSaveable { mutableStateOf(false) }
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -61,53 +70,114 @@ fun CalendarScreen(
             }
         }
         Column(modifier = Modifier.fillMaxSize()) {
-            Calendar(date)
+            Calendar(date, historyViewModel)
+            BothText("수입", moneyConverter(historyViewModel.incomeMoney.value), Green6)
+            Divider(modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp), color = LightPurple)
+            BothText("지출", "-"  + moneyConverter(historyViewModel.expenseMoney.value), Red)
+            Divider(modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp), color = LightPurple)
+            BothText("총합", moneyConverter(historyViewModel.incomeMoney.value - historyViewModel.expenseMoney.value), Purple)
+            Divider(modifier = Modifier.padding(top = 8.dp), color = Purple)
         }
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.N)
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun Calendar(date: Date) {
+fun Calendar(
+    date: Date,
+    viewModel: HistoryViewModel
+) {
     val calendar = getCalendar(date)
-
-    LazyVerticalGrid(cells = GridCells.Fixed(7)){
+    LazyVerticalGrid(cells = GridCells.Fixed(7)) {
         calendar.forEach {
             item {
-                Column(modifier = Modifier
-                    .border(0.5.dp, LightPurple)
-                    .size(72.dp)
-                    .padding(4.dp)) {
-                    Text(text = "5,400", style = MaterialTheme.typography.caption, color = Green6)
-                    Text(text = "-5,400", style = MaterialTheme.typography.caption, color = Red)
-                    Text(text = "5,400", style = MaterialTheme.typography.caption, color = Purple)
-                    Text(text = it.text.toString(), style = MaterialTheme.typography.caption, color = it.color, modifier = Modifier.align(Alignment.End))
+                Column(
+                    modifier = Modifier
+                        .border(0.5.dp, LightPurple)
+                        .size(72.dp)
+                        .padding(4.dp),
+                    verticalArrangement = Arrangement.Bottom
+                ) {
+                    if (it.color == Purple) {
+                        if (viewModel.incomeMoneyOfDay.containsKey(it.day) && viewModel.incomeMoneyOfDay[it.day]!! > 0L)
+                            Text(
+                                text = moneyConverter(viewModel.incomeMoneyOfDay[it.day]!!),
+                                style = MaterialTheme.typography.caption,
+                                color = Green6,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        if (viewModel.expenseMoneyOfDay.containsKey(it.day) && viewModel.expenseMoneyOfDay[it.day]!! > 0L)
+                            Text(
+                                text = "-${moneyConverter(viewModel.expenseMoneyOfDay[it.day]!!)}",
+                                style = MaterialTheme.typography.caption,
+                                color = Red,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        if ((viewModel.incomeMoneyOfDay.getOrDefault(it.day, 0L) - viewModel.expenseMoneyOfDay.getOrDefault(it.day, 0L)) != 0L)
+                            Text(
+                                text = moneyConverter(
+                                    (viewModel.incomeMoneyOfDay.getOrDefault(it.day, 0L) - viewModel.expenseMoneyOfDay.getOrDefault(
+                                        it.day,
+                                        0L
+                                    ))
+                                ),
+                                style = MaterialTheme.typography.caption,
+                                color = Purple,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                    }
+                    Text(
+                        text = it.day.toString(),
+                        style = MaterialTheme.typography.caption,
+                        color = it.color,
+                        modifier = Modifier.align(Alignment.End),
+                        overflow = TextOverflow.Ellipsis
+                    )
                 }
             }
         }
     }
 }
 
+@Composable
+private fun BothText(
+    leftText: String,
+    rightText: String,
+    textColor: Color
+) {
+    Box(modifier = Modifier
+        .fillMaxWidth()
+        .padding(start = 16.dp, end = 16.dp, top = 8.dp)) {
+        Text(text = leftText, modifier = Modifier.align(Alignment.CenterStart), fontWeight = FontWeight.Bold)
+        Text(text = rightText, Modifier.align(Alignment.CenterEnd), color = textColor, fontWeight = FontWeight.Bold)
+    }
+}
+
 private fun getCalendar(date: Date): List<CalendarText> {
-    var number = getDayOfWeekNumber(Date(date.year,date.month,1))
-    var count = if(number in 0..5) number + 1 else 0
+    var number = getDayOfWeekNumber(Date(date.year, date.month, 1))
+    var count = if (number in 0..5) number + 1 else 0
     val calendar = mutableListOf<CalendarText>()
     val prevDate = decreaseDate(date)
     val prevLength = getEndOfMonth(prevDate)
-    for(i in (count - 1) downTo 0) calendar.add(CalendarText(prevLength - i, Purple40))
+    for (i in (count - 1) downTo 0) calendar.add(CalendarText(prevLength - i, Purple40))
     val curLength = getEndOfMonth(date)
-    for(i in 1 .. curLength) calendar.add(CalendarText(i, Purple))
-    number = getDayOfWeekNumber(Date(date.year,date.month,curLength))
-    count = if(number in 0..5) 5 - number else 6
-    for(i in 1..count) calendar.add(CalendarText(i, Purple40))
+    for (i in 1..curLength) calendar.add(CalendarText(i, Purple))
+    number = getDayOfWeekNumber(Date(date.year, date.month, curLength))
+    count = if (number in 0..5) 5 - number else 6
+    for (i in 1..count) calendar.add(CalendarText(i, Purple40))
     return calendar
 }
 
 data class CalendarText(
-    val text: Int,
+    val day: Int,
     val color: Color
 )
 
+@RequiresApi(Build.VERSION_CODES.N)
 @Preview
 @Composable
 fun CalendarItemPreview() {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
@@ -1,13 +1,115 @@
 package com.example.android_accountbook_13.presenter.calendar
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import android.util.Log
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.example.android_accountbook_13.ui.theme.Blue1
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.android_accountbook_13.R
+import com.example.android_accountbook_13.presenter.component.TopAppBar
+import com.example.android_accountbook_13.presenter.component.YearMonthDatePicker
+import com.example.android_accountbook_13.presenter.history.HistoryViewModel
+import com.example.android_accountbook_13.ui.theme.*
+import com.example.android_accountbook_13.utils.*
 
 @Composable
-fun CalendarScreen() {
-    Box(modifier = Modifier.fillMaxSize().background(Blue1))
+fun CalendarScreen(
+    historyViewModel: HistoryViewModel
+) {
+    var date by historyViewModel.date
+    var isDialog by rememberSaveable { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = getYearMonthString(date),
+                titleOnClick = { isDialog = true },
+                leftVectorResource = R.drawable.ic_left,
+                rightVectorResource = R.drawable.ic_right,
+                onLeftClick = {
+                    date = decreaseDate(date)
+                },
+                onRightClick = {
+                    date = increaseDate(date)
+                }
+            )
+        },
+        backgroundColor = MaterialTheme.colors.background
+    ) {
+        if (isDialog) {
+            Dialog(onDismissRequest = { isDialog = false }) {
+                YearMonthDatePicker(onDismissRequest = { isDialog = false }) { year, month ->
+                    date = Date(year, month, 1)
+                    isDialog = false
+                }
+            }
+        }
+        Column(modifier = Modifier.fillMaxSize()) {
+            Calendar(date)
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun Calendar(date: Date) {
+    val calendar = getCalendar(date)
+
+    LazyVerticalGrid(cells = GridCells.Fixed(7)){
+        calendar.forEach {
+            item {
+                Column(modifier = Modifier
+                    .border(0.5.dp, LightPurple)
+                    .size(72.dp)
+                    .padding(4.dp)) {
+                    Text(text = "5,400", style = MaterialTheme.typography.caption, color = Green6)
+                    Text(text = "-5,400", style = MaterialTheme.typography.caption, color = Red)
+                    Text(text = "5,400", style = MaterialTheme.typography.caption, color = Purple)
+                    Text(text = it.text.toString(), style = MaterialTheme.typography.caption, color = it.color, modifier = Modifier.align(Alignment.End))
+                }
+            }
+        }
+    }
+}
+
+private fun getCalendar(date: Date): List<CalendarText> {
+    var number = getDayOfWeekNumber(Date(date.year,date.month,1))
+    var count = if(number in 0..5) number + 1 else 0
+    val calendar = mutableListOf<CalendarText>()
+    val prevDate = decreaseDate(date)
+    val prevLength = getEndOfMonth(prevDate)
+    for(i in (count - 1) downTo 0) calendar.add(CalendarText(prevLength - i, Purple40))
+    val curLength = getEndOfMonth(date)
+    for(i in 1 .. curLength) calendar.add(CalendarText(i, Purple))
+    number = getDayOfWeekNumber(Date(date.year,date.month,curLength))
+    count = if(number in 0..5) 5 - number else 6
+    for(i in 1..count) calendar.add(CalendarText(i, Purple40))
+    return calendar
+}
+
+data class CalendarText(
+    val text: Int,
+    val color: Color
+)
+
+@Preview
+@Composable
+fun CalendarItemPreview() {
+    CalendarScreen(historyViewModel = hiltViewModel())
 }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
@@ -134,10 +134,8 @@ fun AddingScreen(
                         } else {
                             if (type) {
                                 if (title == "수입") {
-                                    Log.d("Test","수입 Insert")
                                     viewModel.insertCategory(Category(null, text, color, 0))
                                 } else {
-                                    Log.d("Test","지출 Insert")
                                     viewModel.insertCategory(Category(null, text, color, 1))
                                 }
                             } else {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -1,5 +1,6 @@
 package com.example.android_accountbook_13.presenter.history
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -83,7 +84,6 @@ fun HistoryScreen(
         val expenseMoney by historyViewModel.expenseMoney.collectAsState()
         historyViewModel.getCheckedItems(incomeChecked, expenseChecked)
         val group = checkedItems.groupBy { it.history.day }
-
         if (isDialog) {
             Dialog(onDismissRequest = { isDialog = false }) {
                 YearMonthDatePicker(onDismissRequest = { isDialog = false }) { year, month ->
@@ -111,21 +111,11 @@ fun HistoryScreen(
             if (checkedItems.isNotEmpty()) {
                 LazyColumn {
                     group.forEach { (day, historyList) ->
-                        var income = 0L
-                        var expense = 0L
-                        for (item in historyList) {
-                            if (item.history.methodType == 1) {
-                                income += item.history.money
-                            } else {
-                                expense += item.history.money
-                            }
-                        }
-
                         item {
                             ItemHeader(
                                 date = "${date.month}월 ${day}일",
-                                income = income,
-                                expense = expense,
+                                income = historyViewModel.incomeMoneyOfDay[day] ?: 0,
+                                expense = historyViewModel.expenseMoneyOfDay[day] ?: 0,
                                 incomeChecked,
                                 expenseChecked
                             )

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -86,8 +86,8 @@ fun HistoryScreen(
 
         if (isDialog) {
             Dialog(onDismissRequest = { isDialog = false }) {
-                YearMonthDayDatePicker(onDismissRequest = { isDialog = false }) { year, month, day ->
-                    date = Date(year, month, day)
+                YearMonthDatePicker(onDismissRequest = { isDialog = false }) { year, month ->
+                    date = Date(year, month, 1)
                     isDialog = false
                 }
             }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
@@ -26,12 +26,15 @@ class HistoryViewModel @Inject constructor(
     val checkedItems: StateFlow<List<AccountBookItem>> get() = _checkedItems
 
     private val _incomeMoney = MutableStateFlow<Long>(0L)
-    val incomeMoney: StateFlow<Long> get() = _incomeMoney
+    val     incomeMoney: StateFlow<Long> get() = _incomeMoney
 
     private val _expenseMoney = MutableStateFlow<Long>(0L)
     val expenseMoney: StateFlow<Long> get() = _expenseMoney
 
     var date = mutableStateOf(getCurrentDate())
+
+    val incomeMoneyOfDay = mutableMapOf<Int,Long>()
+    val expenseMoneyOfDay = mutableMapOf<Int,Long>()
 
     fun getAccountBookItems() {
         viewModelScope.launch {
@@ -54,6 +57,22 @@ class HistoryViewModel @Inject constructor(
             } else {
                 false
             }
+        }
+        val group = _checkedItems.value.groupBy { it.history.day }
+        incomeMoneyOfDay.clear()
+        expenseMoneyOfDay.clear()
+        group.forEach{ (day, historyList) ->
+            var income = 0L
+            var expense = 0L
+            for (item in historyList) {
+                if (item.history.methodType == 1) {
+                    income += item.history.money
+                } else {
+                    expense += item.history.money
+                }
+            }
+            incomeMoneyOfDay[day] = income
+            expenseMoneyOfDay[day] = expense
         }
     }
 

--- a/app/src/main/java/com/example/android_accountbook_13/utils/Date.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/utils/Date.kt
@@ -16,10 +16,14 @@ fun getCurrentDate(): Date {
 
 fun getDayOfWeek(date: Date): String {
     val dayOfWeekName = arrayOf("월요일","화요일","수요일","목요일","금요일","토요일","일요일")
+    val number = getDayOfWeekNumber(date)
+    return dayOfWeekName[number - 1]
+}
+
+fun getDayOfWeekNumber(date: Date): Int {
     val date = LocalDate.of(date.year,date.month,date.day)
     val dayOfWeek = date.dayOfWeek
-    val number = dayOfWeek.value
-    return dayOfWeekName[number - 1]
+    return dayOfWeek.value - 1
 }
 
 fun getYearMonthString(date: Date): String {
@@ -55,4 +59,8 @@ fun decreaseDate(date: Date): Date {
         newDate.year--
     }
     return newDate
+}
+
+fun getEndOfMonth(date: Date): Int {
+    return LocalDate.of(date.year,date.month,date.day).lengthOfMonth()
 }

--- a/app/src/main/java/com/example/android_accountbook_13/utils/Date.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/utils/Date.kt
@@ -17,7 +17,7 @@ fun getCurrentDate(): Date {
 fun getDayOfWeek(date: Date): String {
     val dayOfWeekName = arrayOf("월요일","화요일","수요일","목요일","금요일","토요일","일요일")
     val number = getDayOfWeekNumber(date)
-    return dayOfWeekName[number - 1]
+    return dayOfWeekName[number]
 }
 
 fun getDayOfWeekNumber(date: Date): Int {

--- a/app/src/main/java/com/example/android_accountbook_13/utils/MoneyConverter.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/utils/MoneyConverter.kt
@@ -2,9 +2,13 @@ package com.example.android_accountbook_13.utils
 
 fun moneyConverter(money: Long) : String {
     val moneyString = StringBuilder(money.toString()).reverse()
+    if(money < 0) moneyString.deleteCharAt(moneyString.lastIndex)
     val count = (moneyString.length - 1) / 3
     for(i in 1..count) {
         moneyString.insert(i * 3 + i - 1, ",")
     }
-    return moneyString.reverse().toString()
+    return if(money < 0)
+        "-${moneyString.reverse()}"
+    else
+        moneyString.reverse().toString()
 }

--- a/app/src/test/java/com/example/android_accountbook_13/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/android_accountbook_13/ExampleUnitTest.kt
@@ -14,6 +14,6 @@ import org.threeten.bp.LocalDate
 class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
-        assertEquals(4, getDayOfWeek(Date(2022,7,31)))
+        assertEquals(4, LocalDate.of(2022,2,1).lengthOfMonth())
     }
 }


### PR DESCRIPTION
## 개요

- 이슈 번호: #30 
- 내용: 달력 화면과 기능을 구현한다.

## 작업사항

- 화면 디자인
- 해당 달, 저번 달, 다음 달의 날짜 구하기
- 데이터 표시
- 
## 이슈
- 공통으로 쓰이는 코드가 매우 많음
- History, Calendar, Statistics Screen 모두 같은 ViewModel을 공유하니,
한 화면에서 데이터가 갱신되면 다른 화면에서는 다시 database를 조회할 필요 없이 저장되어 있는 데이터를 가져다 쓰려했지만
생각처럼 구현이 안 되었음
