### PR TITLE
[FEAT] 데이터 CRUD 연산시 오류처리 

### DIFF
--- a/app/src/main/java/com/example/android_accountbook_13/data/DataResponse.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/DataResponse.kt
@@ -3,4 +3,5 @@ package com.example.android_accountbook_13.data
 sealed class DataResponse<T> {
     data class Success<T>(val data: T? = null): DataResponse<T>()
     data class Error<T>(val errorMessage: String = "DataBase를 불러오지 못 했습니다."): DataResponse<T>()
+    object Empty : DataResponse<Unit>()
 }

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/datasource/LocalDataSource.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/datasource/LocalDataSource.kt
@@ -9,7 +9,7 @@ interface LocalDataSource {
     fun getHistory(year: Int, month: Int): Result<Cursor>
     fun insertHistory(history: History): Result<Unit>
     fun updateHistory(history: History): Result<Unit>
-    fun deleteHistory(historyId: Int): Result<Unit>
+    fun deleteHistory(historyIds: List<Int>): Result<Unit>
 
     fun getAllCategory(): Result<Cursor>
     fun getIncomeCategory(): Result<Cursor>

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/datasource/LocalDataSourceImpl.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/datasource/LocalDataSourceImpl.kt
@@ -1,7 +1,9 @@
 package com.example.android_accountbook_13.data.local.datasource
 
 import android.database.Cursor
+import android.text.TextUtils
 import android.util.Log
+import androidx.compose.ui.unit.TextUnit
 import com.example.android_accountbook_13.data.dto.Category
 import com.example.android_accountbook_13.data.dto.History
 import com.example.android_accountbook_13.data.dto.Method
@@ -46,10 +48,10 @@ class LocalDataSourceImpl @Inject constructor(
             )
         }
 
-    override fun deleteHistory(historyId: Int): Result<Unit> =
+    override fun deleteHistory(historyIds: List<Int>): Result<Unit> =
         runCatching {
             db.writableDatabase.execSQL(
-                "DELETE FROM history WHERE id = ${historyId};"
+                "DELETE FROM history WHERE id IN (${TextUtils.join(",",historyIds)});"
             )
         }
 

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/repository/accountbook/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/repository/accountbook/AccountRepositoryImpl.kt
@@ -15,7 +15,7 @@ class AccountRepositoryImpl @Inject constructor(
     private val localDataSource: LocalDataSourceImpl
 ) : AccountRepository {
     override fun getAccountBook(year: Int, month: Int): DataResponse<List<AccountBookItem>> {
-        val cursor = localDataSource.getAccountBook(year, month).getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getAccountBook(year, month).getOrNull() ?: return DataResponse.Error("내역을 불러오지 못 했습니다.")
         val itemList = mutableListOf<AccountBookItem>()
         while (cursor.moveToNext()) {
             itemList.add(

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/repository/category/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/repository/category/CategoryRepositoryImpl.kt
@@ -12,35 +12,32 @@ class CategoryRepositoryImpl @Inject constructor(
     private val localDataSource: LocalDataSourceImpl
 ) : CategoryRepository {
     override fun getAllCategory(): DataResponse<List<Category>> {
-        val cursor = localDataSource.getAllCategory().getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getAllCategory().getOrNull() ?: return DataResponse.Error("전체 카테고리를 불러오지 못 했습니다.")
         return cursorToCategory(cursor)
     }
 
     override fun getIncomeCategory(): DataResponse<List<Category>> {
-        val cursor = localDataSource.getIncomeCategory().getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getIncomeCategory().getOrNull() ?: return DataResponse.Error("수입 카테고리를 불러오지 못 했습니다.")
         return cursorToCategory(cursor)
     }
 
     override fun getExpenseCategory(): DataResponse<List<Category>> {
-        val cursor = localDataSource.getExpenseCategory().getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getExpenseCategory().getOrNull() ?: return DataResponse.Error("지출 카테고리를 불러오지 못 했습니다.")
         return cursorToCategory(cursor)
     }
 
     override fun insertCategory(category: Category): DataResponse<Unit> {
-        if(localDataSource.insertCategory(category).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.insertCategory(category).getOrNull() == null) return DataResponse.Error("카테고리를 추가하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 
     override fun updateCategory(category: Category): DataResponse<Unit> {
-        if(localDataSource.updateCategory(category).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.updateCategory(category).getOrNull() == null) return DataResponse.Error("카테고리를 수정하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 
     override fun deleteCategory(categoryId: Int): DataResponse<Unit> {
-        if(localDataSource.deleteCategory(categoryId).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.deleteCategory(categoryId).getOrNull() == null) return DataResponse.Error("카테고리를 삭제하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/repository/history/HistoryRepository.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/repository/history/HistoryRepository.kt
@@ -7,5 +7,5 @@ interface HistoryRepository {
     fun getHistory(year: Int, month: Int): DataResponse<List<History>>
     fun insertHistory(history: History): DataResponse<Unit>
     fun updateHistory(history: History): DataResponse<Unit>
-    fun deleteHistory(historyId: Int): DataResponse<Unit>
+    fun deleteHistory(historyIds: List<Int>): DataResponse<Unit>
 }

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/repository/history/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/repository/history/HistoryRepositoryImpl.kt
@@ -30,8 +30,8 @@ private val localDataSource: LocalDataSourceImpl
         return DataResponse.Success(Unit)
     }
 
-    override fun deleteHistory(historyId: Int): DataResponse<Unit> {
-        if(localDataSource.deleteHistory(historyId).getOrNull() == null)
+    override fun deleteHistory(historyIds: List<Int>): DataResponse<Unit> {
+        if(localDataSource.deleteHistory(historyIds).getOrNull() == null)
             return DataResponse.Error()
         return DataResponse.Success(Unit)
     }

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/repository/history/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/repository/history/HistoryRepositoryImpl.kt
@@ -10,7 +10,7 @@ class HistoryRepositoryImpl @Inject constructor(
 private val localDataSource: LocalDataSourceImpl
 ) : HistoryRepository {
     override fun getHistory(year: Int, month: Int): DataResponse<List<History>> {
-        val cursor = localDataSource.getHistory(year, month).getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getHistory(year, month).getOrNull() ?: return DataResponse.Error("내역을 불러오지 못 했습니다.")
         val itemList = mutableListOf<History>()
         while (cursor.moveToNext()) {
             itemList.add(getHistoryFromCursor(cursor,0))
@@ -19,20 +19,17 @@ private val localDataSource: LocalDataSourceImpl
     }
 
     override fun insertHistory(history: History): DataResponse<Unit> {
-        if(localDataSource.insertHistory(history).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.insertHistory(history).getOrNull() == null) return DataResponse.Error("내역을 추가하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 
     override fun updateHistory(history: History): DataResponse<Unit> {
-        if(localDataSource.updateHistory(history).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.updateHistory(history).getOrNull() == null) return DataResponse.Error("내역을 수정하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 
     override fun deleteHistory(historyIds: List<Int>): DataResponse<Unit> {
-        if(localDataSource.deleteHistory(historyIds).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.deleteHistory(historyIds).getOrNull() == null) return DataResponse.Error("내역을 삭제하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 

--- a/app/src/main/java/com/example/android_accountbook_13/data/local/repository/method/MethodRepositoryImpl.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/local/repository/method/MethodRepositoryImpl.kt
@@ -1,12 +1,8 @@
 package com.example.android_accountbook_13.data.local.repository.method
 
-import android.database.Cursor
 import com.example.android_accountbook_13.data.DataResponse
-import com.example.android_accountbook_13.data.dto.History
 import com.example.android_accountbook_13.data.dto.Method
 import com.example.android_accountbook_13.data.local.datasource.LocalDataSourceImpl
-import com.example.android_accountbook_13.utils.getCategoryFromCursor
-import com.example.android_accountbook_13.utils.getHistoryFromCursor
 import com.example.android_accountbook_13.utils.getMethodFromCursor
 import javax.inject.Inject
 
@@ -14,7 +10,7 @@ class MethodRepositoryImpl @Inject constructor(
     private val localDataSource: LocalDataSourceImpl
 ) : MethodRepository {
     override fun getAllMethod(): DataResponse<List<Method>> {
-        val cursor = localDataSource.getAllMethod().getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getAllMethod().getOrNull() ?: return DataResponse.Error("결제 수단을 불러오지 못 했습니다.")
         val itemList = mutableListOf<Method>()
         while (cursor.moveToNext()) {
             itemList.add(getMethodFromCursor(cursor,0))
@@ -23,26 +19,23 @@ class MethodRepositoryImpl @Inject constructor(
     }
 
     override fun getMethod(id: Int): DataResponse<Method> {
-        val cursor = localDataSource.getMethod(id).getOrNull() ?: return DataResponse.Error()
+        val cursor = localDataSource.getMethod(id).getOrNull() ?: return DataResponse.Error("결제 수단을 불러오지 못 했습니다.")
         cursor.moveToNext()
         return DataResponse.Success(getMethodFromCursor(cursor,0))
     }
 
     override fun insertMethod(method : Method): DataResponse<Unit> {
-        if(localDataSource.insertMethod(method).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.insertMethod(method).getOrNull() == null) return DataResponse.Error("결제 수단을 추가하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 
     override fun updateMethod(method : Method): DataResponse<Unit> {
-        if(localDataSource.updateMethod(method).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.updateMethod(method).getOrNull() == null) return DataResponse.Error("결제 수단을 수정하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 
     override fun deleteMethod(methodId: Int): DataResponse<Unit> {
-        if(localDataSource.deleteMethod(methodId).getOrNull() == null)
-            return DataResponse.Error()
+        if(localDataSource.deleteMethod(methodId).getOrNull() == null) return DataResponse.Error("결제 수단을 삭제하지 못 했습니다.")
         return DataResponse.Success(Unit)
     }
 }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/MainActivity.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/MainActivity.kt
@@ -14,7 +14,7 @@ import com.example.android_accountbook_13.data.local.datasource.LocalDataSourceI
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class   MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.example.android_accountbook_13.R
+import com.example.android_accountbook_13.data.DataResponse
 import com.example.android_accountbook_13.data.dto.Category
 import com.example.android_accountbook_13.data.dto.Method
 import com.example.android_accountbook_13.presenter.component.AddingButton
@@ -31,6 +33,7 @@ import com.example.android_accountbook_13.presenter.setting.component.SettingHea
 import com.example.android_accountbook_13.ui.theme.LightPurple
 import com.example.android_accountbook_13.ui.theme.OffWhite
 import com.example.android_accountbook_13.ui.theme.Purple
+import com.example.android_accountbook_13.utils.showToast
 
 @Composable
 fun AddingScreen(
@@ -57,6 +60,16 @@ fun AddingScreen(
     var text by rememberSaveable { mutableStateOf("") }
     var color by rememberSaveable { mutableStateOf(if(title == "수입") incomeColors[0] else expenseColors[0]) }
     var selectedIndex by rememberSaveable { mutableStateOf(0) }
+
+    var isSuccess by viewModel.isSuccess
+
+    if(isSuccess.event is DataResponse.Success) {
+        isSuccess(DataResponse.Empty)
+        navController.popBackStack()
+    } else if(isSuccess.event is DataResponse.Error) {
+        showToast(LocalContext.current, (isSuccess.event as DataResponse.Error<*>).errorMessage)
+        isSuccess(DataResponse.Empty)
+    }
 
     Scaffold(
         topBar = {
@@ -143,7 +156,6 @@ fun AddingScreen(
                                 }
                             }
                         }
-                        navController.popBackStack()
                     }
                 )
             }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -77,8 +77,8 @@ fun AddingHistoryScreen(
 
     if(isHistorySuccess.event is DataResponse.Success) {
         historyViewModel.getAccountBookItems()
-        navHostController.popBackStack()
         isHistorySuccess(DataResponse.Empty)
+        navHostController.popBackStack()
     } else if(isHistorySuccess.event is DataResponse.Error) {
         showToast(LocalContext.current, (isHistorySuccess.event as DataResponse.Error<*>).errorMessage)
         isHistorySuccess(DataResponse.Empty)

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavHostController
 import com.example.android_accountbook_13.R
+import com.example.android_accountbook_13.data.DataResponse
 import com.example.android_accountbook_13.data.dto.Category
 import com.example.android_accountbook_13.data.dto.History
 import com.example.android_accountbook_13.data.dto.Method
@@ -36,6 +38,7 @@ import com.example.android_accountbook_13.ui.theme.Purple
 import com.example.android_accountbook_13.utils.Date
 import com.example.android_accountbook_13.utils.getCurrentDate
 import com.example.android_accountbook_13.utils.getYearMonthDayString
+import com.example.android_accountbook_13.utils.showToast
 
 @Composable
 fun AddingHistoryScreen(
@@ -69,6 +72,17 @@ fun AddingHistoryScreen(
     val methods by settingViewModel.methods.collectAsState()
     val incomeCategories by settingViewModel.incomeCategories.collectAsState()
     val expenseCategories by settingViewModel.expenseCategories.collectAsState()
+
+    var isHistorySuccess by historyViewModel.isSuccess
+
+    if(isHistorySuccess.event is DataResponse.Success) {
+        historyViewModel.getAccountBookItems()
+        navHostController.popBackStack()
+        isHistorySuccess(DataResponse.Empty)
+    } else if(isHistorySuccess.event is DataResponse.Error) {
+        showToast(LocalContext.current, (isHistorySuccess.event as DataResponse.Error<*>).errorMessage)
+        isHistorySuccess(DataResponse.Empty)
+    }
 
     Scaffold(
         topBar = {
@@ -202,7 +216,6 @@ fun AddingHistoryScreen(
                             )
                         )
                     }
-                    navHostController.popBackStack()
                 }
             }
         }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -1,6 +1,6 @@
 package com.example.android_accountbook_13.presenter.history
 
-import android.util.Log
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,35 +15,46 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavHostController
 import com.example.android_accountbook_13.R
+import com.example.android_accountbook_13.data.DataResponse
 import com.example.android_accountbook_13.data.dto.AccountBookItem
 import com.example.android_accountbook_13.presenter.component.*
 import com.example.android_accountbook_13.presenter.history.component.HistoryFab
 import com.example.android_accountbook_13.ui.theme.LightPurple
 import com.example.android_accountbook_13.ui.theme.Purple
-import com.example.android_accountbook_13.utils.Date
-import com.example.android_accountbook_13.utils.decreaseDate
-import com.example.android_accountbook_13.utils.getYearMonthString
-import com.example.android_accountbook_13.utils.increaseDate
+import com.example.android_accountbook_13.utils.*
 
+@SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun HistoryScreen(
     navHostController: NavHostController,
     historyViewModel: HistoryViewModel,
 ) {
-    historyViewModel.getAccountBookItems()
-
+    if(historyViewModel.accountBookItems.value.isEmpty()) {
+        historyViewModel.getAccountBookItems()
+    }
     var date by historyViewModel.date
     var incomeChecked by rememberSaveable { mutableStateOf(true) }
     var expenseChecked by rememberSaveable { mutableStateOf(true) }
     var isEditMode by rememberSaveable { mutableStateOf(false) }
     val deleteIdList = rememberSaveable { mutableListOf<Int>()}
     var isDialog by rememberSaveable { mutableStateOf(false) }
+    var isSuccess by historyViewModel.isSuccess
+
+    if(isSuccess.event is DataResponse.Success) {
+        historyViewModel.getAccountBookItems()
+        isSuccess(DataResponse.Empty)
+    } else if(isSuccess.event is DataResponse.Error) {
+        showToast(LocalContext.current, (isSuccess.event as DataResponse.Error<*>).errorMessage)
+        isSuccess(DataResponse.Empty)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -61,7 +72,6 @@ fun HistoryScreen(
                 onRightClick = {
                     if(isEditMode) {
                         historyViewModel.deleteHistory(deleteIdList)
-                        historyViewModel.getAccountBookItems()
                         isEditMode = false
                         deleteIdList.clear()
                     }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -44,7 +44,6 @@ fun HistoryScreen(
     var isEditMode by rememberSaveable { mutableStateOf(false) }
     val deleteIdList = rememberSaveable { mutableListOf<Int>()}
     var isDialog by rememberSaveable { mutableStateOf(false) }
-
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.android_accountbook_13.presenter.history
 
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -84,11 +83,9 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    fun deleteHistory(deleteIdList: List<Int>) {
+    fun deleteHistory(historyIds: List<Int>) {
         viewModelScope.launch {
-            deleteIdList.forEach { id ->
-                historyRepository.deleteHistory(id)
-            }
+            historyRepository.deleteHistory(historyIds)
         }
     }
 

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
@@ -1,6 +1,9 @@
 package com.example.android_accountbook_13.presenter.history
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.android_accountbook_13.data.DataResponse
@@ -8,6 +11,7 @@ import com.example.android_accountbook_13.data.dto.AccountBookItem
 import com.example.android_accountbook_13.data.dto.History
 import com.example.android_accountbook_13.data.local.repository.accountbook.AccountRepository
 import com.example.android_accountbook_13.data.local.repository.history.HistoryRepository
+import com.example.android_accountbook_13.utils.Event
 import com.example.android_accountbook_13.utils.getCurrentDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,6 +40,9 @@ class HistoryViewModel @Inject constructor(
 
     val incomeMoneyOfDay = mutableMapOf<Int, Long>()
     val expenseMoneyOfDay = mutableMapOf<Int, Long>()
+
+    var isSuccess by mutableStateOf(Event(DataResponse.Empty))
+
 
     fun getAccountBookItems() {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
@@ -1,8 +1,6 @@
 package com.example.android_accountbook_13.presenter.history
 
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.android_accountbook_13.data.DataResponse
@@ -40,7 +38,7 @@ class HistoryViewModel @Inject constructor(
     val incomeMoneyOfDay = mutableMapOf<Int, Long>()
     val expenseMoneyOfDay = mutableMapOf<Int, Long>()
 
-    var isSuccess by mutableStateOf(Event(DataResponse.Empty))
+    var isSuccess = mutableStateOf(Event(DataResponse.Empty))
 
 
     fun getAccountBookItems() {
@@ -85,25 +83,19 @@ class HistoryViewModel @Inject constructor(
 
     fun deleteHistory(historyIds: List<Int>) {
         viewModelScope.launch {
-            historyRepository.deleteHistory(historyIds)
+            isSuccess.value = Event(historyRepository.deleteHistory(historyIds))
         }
     }
 
     fun insertHistory(history: History) {
         viewModelScope.launch {
-            val response = historyRepository.insertHistory(history)
-            if (response is DataResponse.Error) {
-
-            }
+            isSuccess.value = Event(historyRepository.insertHistory(history))
         }
     }
 
     fun updateHistory(history: History) {
         viewModelScope.launch {
-            val response = historyRepository.updateHistory(history)
-            if (response is DataResponse.Error) {
-
-            }
+            isSuccess.value = Event(historyRepository.updateHistory(history))
         }
     }
 

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.android_accountbook_13.presenter.setting
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.android_accountbook_13.data.DataResponse
@@ -7,6 +8,7 @@ import com.example.android_accountbook_13.data.dto.Category
 import com.example.android_accountbook_13.data.dto.Method
 import com.example.android_accountbook_13.data.local.repository.category.CategoryRepository
 import com.example.android_accountbook_13.data.local.repository.method.MethodRepository
+import com.example.android_accountbook_13.utils.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +28,8 @@ class SettingViewModel @Inject constructor(
 
     private val _expenseCategories = MutableStateFlow<List<Category>>(emptyList())
     val expenseCategories: StateFlow<List<Category>> get() = _expenseCategories
+
+    var isSuccess = mutableStateOf(Event(DataResponse.Empty))
 
     fun getAllMethod() {
         viewModelScope.launch {
@@ -56,37 +60,25 @@ class SettingViewModel @Inject constructor(
 
     fun insertMethod(method: Method) {
         viewModelScope.launch {
-            val response = methodRepository.insertMethod(method)
-            if (response is DataResponse.Error) {
-
-            }
+            isSuccess.value = Event(methodRepository.insertMethod(method))
         }
     }
 
     fun insertCategory(category: Category) {
         viewModelScope.launch {
-            val response = categoryRepository.insertCategory(category)
-            if (response is DataResponse.Error) {
-
-            }
+            isSuccess.value = Event(categoryRepository.insertCategory(category))
         }
     }
 
     fun updateCategory(category: Category) {
         viewModelScope.launch {
-            val response = categoryRepository.updateCategory(category)
-            if (response is DataResponse.Error) {
-
-            }
+            isSuccess.value = Event(categoryRepository.updateCategory(category))
         }
     }
 
     fun updateMethod(method: Method) {
         viewModelScope.launch {
-            val response = methodRepository.updateMethod(method)
-            if (response is DataResponse.Error) {
-
-            }
+            isSuccess.value = Event(methodRepository.updateMethod(method))
         }
     }
 }

--- a/app/src/main/java/com/example/android_accountbook_13/utils/Event.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/utils/Event.kt
@@ -1,0 +1,9 @@
+package com.example.android_accountbook_13.utils
+
+import com.example.android_accountbook_13.data.DataResponse
+
+class Event(var event: DataResponse<*>){
+    operator fun invoke(e: DataResponse<*>) {
+        event = e
+    }
+}

--- a/app/src/main/java/com/example/android_accountbook_13/utils/Toast.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/utils/Toast.kt
@@ -1,0 +1,8 @@
+package com.example.android_accountbook_13.utils
+
+import android.content.Context
+import android.widget.Toast
+
+fun showToast(context: Context, message: String) {
+    Toast.makeText(context,message,Toast.LENGTH_SHORT).show()
+}


### PR DESCRIPTION
## 개요

- 이슈 번호: #40 
- 내용: CRUD 연산 시, 그에 맞는 UI를 보여주거나 이벤트를 발생시킨다.

## 작업사항

- `isSuccess`이라는 stateful한 변수를 만들었다.
만약 데이터의 반환이 성공적으로 이루어진다면 isSuccess이 변경되고,
변경됨에 따라 리컴포지션이 발생하니 if문으로 분기하여 그에 맞는 처리를 해주었다.


## 고민했던 부분
- `isSuccess`가 Success가 되어서 `1`화면에서 `2`화면으로 넘어갔다고 가정했을 때,
`isSuccess`를 다른 상태로 만들어주지 않는다면 `ViewModel` 에 데이터가 남아있으므로
다시 `1`화면으로 돌아가더라도 아무런 과정 없이 다시 `2`화면으로 돌아가게 된다.

- 위 문제를 해결하기 위해서는 `isSuccess`의 상태를 변경시켜주어야 한다.
만약 `Empty`상태로 변경시켜준다면, 기능은 올바르게 동작할 수는 있지만,
상태가 변경됨에 따라 무의미한 리컴포지션이 다시 발생하게 된다.

- 따라서 isSuccess에 들어가는 값을 Event 클래스로 감싸주었다.
```  kotlin
    var isSuccess = mutableStateOf(Event(DataResponse.Empty))
```
리컴포지션은 `isSuccess`라는 변수의 주소가 변경되어야 발생한다고 알고있다. (이건 확실하지 않아서 공부가 필요하다..)
나의 가정이 맞다면 Event 내부에 있는 DataResponse에 값은 변경되어도 리컴포지션이 발생하지 않게되기 때문에
위와 같이 Event 클래스로 감싸주는 방법을 선택했다.