### PR TITLE
[FEAT]  동일 데이터 호출 방지 #42

### DIFF
--- a/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
@@ -41,8 +41,6 @@ import com.example.android_accountbook_13.utils.*
 fun CalendarScreen(
     historyViewModel: HistoryViewModel
 ) {
-    historyViewModel.getAccountBookItems()
-    historyViewModel.getCheckedItems(true,true)
     var date by historyViewModel.date
     var isDialog by rememberSaveable { mutableStateOf(false) }
     Scaffold(
@@ -54,14 +52,17 @@ fun CalendarScreen(
                 rightVectorResource = R.drawable.ic_right,
                 onLeftClick = {
                     date = decreaseDate(date)
+                    historyViewModel.getAccountBookItems()
                 },
                 onRightClick = {
                     date = increaseDate(date)
+                    historyViewModel.getAccountBookItems()
                 }
             )
         },
         backgroundColor = MaterialTheme.colors.background
     ) {
+        historyViewModel.getCheckedItems(true,true)
         if (isDialog) {
             Dialog(onDismissRequest = { isDialog = false }) {
                 YearMonthDatePicker(onDismissRequest = { isDialog = false }) { year, month ->

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
@@ -61,15 +61,27 @@ fun AddingScreen(
     var color by rememberSaveable { mutableStateOf(if(title == "수입") incomeColors[0] else expenseColors[0]) }
     var selectedIndex by rememberSaveable { mutableStateOf(0) }
 
-    var isSuccess by viewModel.isSuccess
+    val isMethodSuccess by viewModel.isMethodSuccess
+    val isCategorySuccess by viewModel.isCategorySuccess
 
-    if(isSuccess.event is DataResponse.Success) {
-        isSuccess(DataResponse.Empty)
+    if(isMethodSuccess.event is DataResponse.Success) {
+        isMethodSuccess(DataResponse.Empty)
+        viewModel.getAllMethod()
         navController.popBackStack()
-    } else if(isSuccess.event is DataResponse.Error) {
-        showToast(LocalContext.current, (isSuccess.event as DataResponse.Error<*>).errorMessage)
-        isSuccess(DataResponse.Empty)
+    } else if(isMethodSuccess.event is DataResponse.Error) {
+        showToast(LocalContext.current, (isMethodSuccess.event as DataResponse.Error<*>).errorMessage)
+        isMethodSuccess(DataResponse.Empty)
     }
+
+    if(isCategorySuccess.event is DataResponse.Success) {
+        isCategorySuccess(DataResponse.Empty)
+        viewModel.getAllCategory()
+        navController.popBackStack()
+    } else if(isCategorySuccess.event is DataResponse.Error) {
+        showToast(LocalContext.current, (isCategorySuccess.event as DataResponse.Error<*>).errorMessage)
+        isCategorySuccess(DataResponse.Empty)
+    }
+
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -49,10 +49,11 @@ fun AddingHistoryScreen(
     settingViewModel: SettingViewModel
 ) {
     settingViewModel.run {
-        getAllMethod()
-        getIncomeCategory()
-        getExpenseCategory()
+        if(methods.value.isEmpty()) getAllMethod()
+        if(incomeCategories.value.isEmpty()) getIncomeCategory()
+        if(expenseCategories.value.isEmpty()) getExpenseCategory()
     }
+
     var price by rememberSaveable { mutableStateOf("") }
     var content by rememberSaveable { mutableStateOf("") }
 
@@ -73,7 +74,7 @@ fun AddingHistoryScreen(
     val incomeCategories by settingViewModel.incomeCategories.collectAsState()
     val expenseCategories by settingViewModel.expenseCategories.collectAsState()
 
-    var isHistorySuccess by historyViewModel.isSuccess
+    val isHistorySuccess by historyViewModel.isSuccess
 
     if(isHistorySuccess.event is DataResponse.Success) {
         historyViewModel.getAccountBookItems()

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -1,6 +1,7 @@
 package com.example.android_accountbook_13.presenter.history
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -40,12 +41,13 @@ fun HistoryScreen(
         historyViewModel.getAccountBookItems()
     }
     var date by historyViewModel.date
+
     var incomeChecked by rememberSaveable { mutableStateOf(true) }
     var expenseChecked by rememberSaveable { mutableStateOf(true) }
     var isEditMode by rememberSaveable { mutableStateOf(false) }
     val deleteIdList = rememberSaveable { mutableListOf<Int>()}
     var isDialog by rememberSaveable { mutableStateOf(false) }
-    var isSuccess by historyViewModel.isSuccess
+    val isSuccess by historyViewModel.isSuccess
 
     if(isSuccess.event is DataResponse.Success) {
         historyViewModel.getAccountBookItems()
@@ -67,7 +69,10 @@ fun HistoryScreen(
                         isEditMode = false
                         deleteIdList.clear()
                     }
-                    else date = decreaseDate(date)
+                    else {
+                        date = decreaseDate(date)
+                        historyViewModel.getAccountBookItems()
+                    }
                 },
                 onRightClick = {
                     if(isEditMode) {
@@ -75,7 +80,10 @@ fun HistoryScreen(
                         isEditMode = false
                         deleteIdList.clear()
                     }
-                    else date = increaseDate(date)
+                    else {
+                        date = increaseDate(date)
+                        historyViewModel.getAccountBookItems()
+                    }
                 }
             )
         },
@@ -102,7 +110,6 @@ fun HistoryScreen(
                 }
             }
         }
-
         Column {
             FilterButton(
                 incomeChecked = incomeChecked,

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.android_accountbook_13.presenter.history
 
+import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingScreen.kt
@@ -27,9 +27,9 @@ fun SettingScreen(
     settingViewModel: SettingViewModel
 ) {
     settingViewModel.run {
-        getAllMethod()
-        getIncomeCategory()
-        getExpenseCategory()
+        if(methods.value.isEmpty()) getAllMethod()
+        if(incomeCategories.value.isEmpty()) getIncomeCategory()
+        if(expenseCategories.value.isEmpty()) getExpenseCategory()
     }
     val methods by settingViewModel.methods.collectAsState()
     val incomeCategories by settingViewModel.incomeCategories.collectAsState()

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingViewModel.kt
@@ -29,7 +29,8 @@ class SettingViewModel @Inject constructor(
     private val _expenseCategories = MutableStateFlow<List<Category>>(emptyList())
     val expenseCategories: StateFlow<List<Category>> get() = _expenseCategories
 
-    var isSuccess = mutableStateOf(Event(DataResponse.Empty))
+    var isMethodSuccess = mutableStateOf(Event(DataResponse.Empty))
+    var isCategorySuccess = mutableStateOf(Event(DataResponse.Empty))
 
     fun getAllMethod() {
         viewModelScope.launch {
@@ -38,6 +39,11 @@ class SettingViewModel @Inject constructor(
                 _methods.value = response.data!!
             }
         }
+    }
+
+    fun getAllCategory() {
+        getIncomeCategory()
+        getExpenseCategory()
     }
 
     fun getIncomeCategory() {
@@ -60,25 +66,25 @@ class SettingViewModel @Inject constructor(
 
     fun insertMethod(method: Method) {
         viewModelScope.launch {
-            isSuccess.value = Event(methodRepository.insertMethod(method))
+            isMethodSuccess.value = Event(methodRepository.insertMethod(method))
         }
     }
 
     fun insertCategory(category: Category) {
         viewModelScope.launch {
-            isSuccess.value = Event(categoryRepository.insertCategory(category))
+            isCategorySuccess.value = Event(categoryRepository.insertCategory(category))
         }
     }
 
     fun updateCategory(category: Category) {
         viewModelScope.launch {
-            isSuccess.value = Event(categoryRepository.updateCategory(category))
+            isCategorySuccess.value = Event(categoryRepository.updateCategory(category))
         }
     }
 
     fun updateMethod(method: Method) {
         viewModelScope.launch {
-            isSuccess.value = Event(methodRepository.updateMethod(method))
+            isMethodSuccess.value = Event(methodRepository.updateMethod(method))
         }
     }
 }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/statistic/StatisticScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/statistic/StatisticScreen.kt
@@ -11,11 +11,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -45,10 +42,9 @@ import java.util.*
 fun StatisticScreen(
     historyViewModel: HistoryViewModel
 ) {
-    historyViewModel.getAccountBookItems()
     var date by historyViewModel.date
     var isDialog by rememberSaveable { mutableStateOf(false) }
-    var totalMoney = historyViewModel.expenseMoney
+    val totalMoney = historyViewModel.expenseMoney.collectAsState()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -58,9 +54,11 @@ fun StatisticScreen(
                 rightVectorResource = R.drawable.ic_right,
                 onLeftClick = {
                     date = decreaseDate(date)
+                    historyViewModel.getAccountBookItems()
                 },
                 onRightClick = {
                     date = increaseDate(date)
+                    historyViewModel.getAccountBookItems()
                 }
             )
         },
@@ -74,12 +72,12 @@ fun StatisticScreen(
                 }
             }
         }
-        val list = getPairList(historyViewModel)
+        val list = if(totalMoney.value > 0 )getPairList(historyViewModel) else emptyList()
 
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
                 BothText(leftText = stringResource(id = R.string.total_payment_of_month), rightText = moneyConverter(totalMoney.value), textColor = Red)
-                Divider(color = Purple, modifier = Modifier.padding(top = 8.dp))   
+                Divider(color = Purple, modifier = Modifier.padding(top = 8.dp))
             }
             item{
                 AndroidView(factory = {


### PR DESCRIPTION
## 개요

- 이슈 번호: #42  
- 내용: 동일한 데이터를 재호출 하는 것을 최대한 방지한다.

## 작업사항

- 데이터가 없을 때 즉, 앱에 처음 진입할 때 한번만 데이터를 호출한다.
- 수정, 삽입, 삭제가 일어날 때 데이터를 호출한다.
- 날짜가 바뀔 때 데이터를 호출한다.
- 위 3가지 경우 외에는 db를 조회하여 데이터를 가져오는 일은 없도록 한다.

## 이슈
ViewModel의 데이터가 있다면 삽입, 삭제, 수정이 일어나지 않는 이상 다시 조회를 하는 일이 없도록 하였지만
이 방법은 만약 원래 데이터가 없다면 (db에 데이터가 하나도 없다면), 조회가 여러번 일어나는 문제가 있다.