### PR TITLE
[FEAT] [35] 수정 화면 진입시 기존의 정보 전달 

### DIFF
--- a/app/src/main/java/com/example/android_accountbook_13/presenter/AccountBookNavHost.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/AccountBookNavHost.kt
@@ -1,5 +1,7 @@
 package com.example.android_accountbook_13.presenter
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -21,6 +23,7 @@ import com.example.android_accountbook_13.presenter.setting.SettingScreen
 import com.example.android_accountbook_13.presenter.setting.SettingViewModel
 import com.example.android_accountbook_13.presenter.statistic.StatisticScreen
 
+@RequiresApi(Build.VERSION_CODES.N)
 @Composable
 fun AccountBookNavHost(
     navController: NavHostController,
@@ -71,13 +74,11 @@ fun AccountBookNavHost(
             route = AddingHistory.route,
             arguments = listOf(
                 navArgument("method") { type = NavType.IntType},
-                navArgument("id") { type = NavType.IntType},
             )
         ) {
             AddingHistoryScreen(
                 navController,
                 method = it.arguments?.getInt("method")!!,
-                id = it.arguments?.getInt("id"),
                 historyViewModel,
                 settingViewModel
             )
@@ -122,7 +123,7 @@ object AddingSetting : AccountBookDestination {
 }
 
 object AddingHistory : AccountBookDestination {
-    override val route: String = "addingHistory/{method},{id}"
+    override val route: String = "addingHistory/{method}"
     override val content: String = "추가"
     override val vectorResource: Int = 0
 }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/AccountBookNavHost.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/AccountBookNavHost.kt
@@ -38,7 +38,7 @@ fun AccountBookNavHost(
         modifier = Modifier.padding(innerPaddingModifier)
     ) {
         composable(History.route) {
-            HistoryScreen(navController,historyViewModel)
+            HistoryScreen(navController, historyViewModel)
         }
 
         composable(Calendar.route) {
@@ -56,14 +56,19 @@ fun AccountBookNavHost(
         composable(
             route = AddingSetting.route,
             arguments = listOf(
-                navArgument("title") { type = NavType.StringType},
-                navArgument("id") { type = NavType.IntType},
-                navArgument("type"){ type = NavType.BoolType}
+                navArgument("title") { type = NavType.StringType },
+                navArgument("name") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                },
+                navArgument("id") { type = NavType.IntType },
+                navArgument("type") { type = NavType.BoolType }
             )
         ) {
             AddingScreen(
                 navController,
                 title = it.arguments?.getString("title")!!,
+                name = it.arguments?.getString("name")!!,
                 id = it.arguments?.getInt("id"),
                 type = it.arguments?.getBoolean("type")!!,
                 settingViewModel
@@ -73,7 +78,7 @@ fun AccountBookNavHost(
         composable(
             route = AddingHistory.route,
             arguments = listOf(
-                navArgument("method") { type = NavType.IntType},
+                navArgument("method") { type = NavType.IntType },
             )
         ) {
             AddingHistoryScreen(
@@ -117,7 +122,7 @@ object Setting : AccountBookDestination {
 }
 
 object AddingSetting : AccountBookDestination {
-    override val route: String = "addingSetting/{title},{id},{type}"
+    override val route: String = "addingSetting?title={title}&name={name}&id={id}&type={type}"
     override val content: String = "추가"
     override val vectorResource: Int = 0
 }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/common/AddingScreen.kt
@@ -39,6 +39,7 @@ import com.example.android_accountbook_13.utils.showToast
 fun AddingScreen(
     navController: NavHostController,
     title: String,
+    name: String,
     id: Int?,
     type: Boolean,
     viewModel: SettingViewModel
@@ -57,7 +58,7 @@ fun AddingScreen(
             "$title ${stringResource(id = R.string.edit_category)}"
         }
     }
-    var text by rememberSaveable { mutableStateOf("") }
+    var text by rememberSaveable { mutableStateOf(name) }
     var color by rememberSaveable { mutableStateOf(if(title == "수입") incomeColors[0] else expenseColors[0]) }
     var selectedIndex by rememberSaveable { mutableStateOf(0) }
 

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -149,7 +149,7 @@ fun AddingHistoryScreen(
                             checkedMethod = method as Method
                             methodExpanded = false
                         },
-                        { navHostController.navigate("addingSetting/결제,-1,true") },
+                        { navHostController.navigate("addingSetting?title=결제&id=-1&type=true") },
                         { methodExpanded = false }
                     )
                 }
@@ -169,8 +169,8 @@ fun AddingHistoryScreen(
                         },
                         {
                             navHostController.navigate(
-                                if (incomeChecked) "addingSetting/수입,-1,true"
-                                else "addingSetting/지출,-1,true"
+                                if (incomeChecked) "addingSetting?title=수입&id=-1&type=true"
+                                else "addingSetting?title=지출&id=-1&type=true"
                             )
                         },
                         { categoryExpanded = false }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -83,10 +83,7 @@ fun HistoryScreen(
         },
         floatingActionButton = {
             HistoryFab(onClick = {
-                navHostController.navigate(
-                    "addingHistory/" +
-                            "${if ((incomeChecked && expenseChecked) || (!incomeChecked && !expenseChecked) || incomeChecked) 0 else 1},-1"
-                )
+                navHostController.navigate("addingHistory/${if ((incomeChecked && expenseChecked) || (!incomeChecked && !expenseChecked) || incomeChecked) 1 else 0}")
             })
         },
         backgroundColor = MaterialTheme.colors.background
@@ -147,7 +144,8 @@ fun HistoryScreen(
                                         deleteIdList.add(id)
                                 },
                                 onClick = {
-                                    navHostController.navigate("addingHistory/${item.history.methodType},${item.history.id}")
+                                    historyViewModel.navItem = item
+                                    navHostController.navigate("addingHistory/${item.history.methodType}")
                                 },
                                 onCheckClick = { id ->
                                     if(deleteIdList.contains(id)) {
@@ -175,7 +173,10 @@ fun HistoryScreen(
                                 lastAccountBookItem,
                                 isEditMode = isEditMode,
                                 onClick = {
-                                    navHostController.navigate("addingHistory/${lastAccountBookItem.history.methodType},${lastAccountBookItem.history.id}")
+                                    Log.d("Test",lastAccountBookItem.toString())
+                                    historyViewModel.navItem = lastAccountBookItem
+                                    Log.d("Test",historyViewModel.navItem.toString())
+                                    navHostController.navigate("addingHistory/${lastAccountBookItem.history.methodType}")
                                 },
                                 onCheckClick = { id ->
                                     if(deleteIdList.contains(id)) {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.android_accountbook_13.presenter.history
 
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -16,7 +15,6 @@ import com.example.android_accountbook_13.utils.Event
 import com.example.android_accountbook_13.utils.getCurrentDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,7 +24,6 @@ class HistoryViewModel @Inject constructor(
     private val historyRepository: HistoryRepository
 ) : ViewModel() {
     private val _accountBookItems = MutableStateFlow<List<AccountBookItem>>(emptyList())
-    val accountBookItems: StateFlow<List<AccountBookItem>> get() = _accountBookItems
 
     private val _checkedItems = mutableStateOf<List<AccountBookItem>>(emptyList())
     val checkedItems: State<List<AccountBookItem>> get() = _checkedItems
@@ -42,6 +39,8 @@ class HistoryViewModel @Inject constructor(
 
     val incomeMoneyOfDay = mutableMapOf<Int, Long>()
     val expenseMoneyOfDay = mutableMapOf<Int, Long>()
+
+    var navItem: AccountBookItem? = null
 
     var isSuccess = mutableStateOf(Event(DataResponse.Empty))
 
@@ -124,7 +123,7 @@ class HistoryViewModel @Inject constructor(
     }
 
     fun getPairList(): List<Pair<Long,Category>> {
-        val expenseHistory = accountBookItems.value.filter { item ->
+        val expenseHistory = _accountBookItems.value.filter { item ->
             item.history.methodType == 0
         }
 

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/setting/SettingScreen.kt
@@ -47,7 +47,7 @@ fun SettingScreen(
                 SettingContent(
                     title = method.name,
                     onClick = {
-                        navController.navigate("addingSetting/결제,${method.id},false")
+                        navController.navigate("addingSetting?title=결제&name=${method.name}&id=${method.id}&type=false")
                     }
                 )
             }
@@ -56,7 +56,7 @@ fun SettingScreen(
                 SettingFooter(
                     title = "${stringResource(id = R.string.payment_method)} ${stringResource(id = R.string.add_item)}",
                     onClick = {
-                        navController.navigate("addingSetting/결제,-1,true")
+                        navController.navigate("addingSetting?title=결제&id=-1&type=true")
                     }
                 )
             }
@@ -70,7 +70,7 @@ fun SettingScreen(
                     title = category.name,
                     category = category,
                     onClick = {
-                        navController.navigate("addingSetting/지출,${category.id},false")
+                        navController.navigate("addingSetting?title=지출&name=${category.name}&id=${category.id}&type=false")
                     }
                 )
             }
@@ -79,7 +79,7 @@ fun SettingScreen(
                 SettingFooter(
                     title = "${stringResource(id = R.string.category_expense)} ${stringResource(id = R.string.add_item)}",
                     onClick = {
-                        navController.navigate("addingSetting/지출,-1,true")
+                        navController.navigate("addingSetting?title=지출&id=-1&type=true")
                     }
                 )
             }
@@ -93,7 +93,7 @@ fun SettingScreen(
                     title = category.name,
                     category = category,
                     onClick = {
-                        navController.navigate("addingSetting/수입,${category.id},false")
+                        navController.navigate("addingSetting?title=수입&name=${category.name}&id=${category.id}&type=false")
                     }
                 )
             }
@@ -102,7 +102,7 @@ fun SettingScreen(
                 SettingFooter(
                     title = "${stringResource(id = R.string.category_income)} ${stringResource(id = R.string.add_item)}",
                     onClick = {
-                        navController.navigate("addingSetting/수입,-1,true")
+                        navController.navigate("addingSetting?title=수입&id=-1&type=true")
                     }
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="total">총합</string>
     <string name="payment">결제</string>
     <string name="name">이름</string>
-    <string name="colors">색</string>
+    <string name="colors">색상</string>
     <string name="year">년</string>
     <string name="month">월</string>
     <string name="day">일자</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <string name="month">월</string>
     <string name="day">일자</string>
     <string name="add">등록</string>
-    <string name="edit">수</string>
-    <string name="date">일</string>
+    <string name="edit">수정</string>
+    <string name="date">일자</string>
     <string name="price">금액</string>
     <string name="content">내용</string>
     <string name="payment_method">결제 수단</string>


### PR DESCRIPTION
## 개요

- 이슈 번호: #35 
- 내용: 기존에 있던 항목을 수정할시, 그 아이템의 정보를 뷰에 띄어준다.

## 작업사항

- 설정 탭은 넘겨야 할 정보가 간단하기 때문에 DeepLink로 인자 전달
- 내역 탭은 넘겨야 할 정보가 복잡하므로 뷰모델에서 공유.