### PR TITLE
[FEAT] [38] UI / UX 개선

### DIFF
--- a/app/src/main/java/com/example/android_accountbook_13/data/dto/Category.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/dto/Category.kt
@@ -1,8 +1,12 @@
 package com.example.android_accountbook_13.data.dto
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class Category(
     val id: Int?,
     val name: String,
     val color: String,
     val type: Int
-)
+): Parcelable

--- a/app/src/main/java/com/example/android_accountbook_13/data/dto/Method.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/data/dto/Method.kt
@@ -1,6 +1,10 @@
 package com.example.android_accountbook_13.data.dto
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class Method(
     val id: Int?,
     val name: String
-)
+): Parcelable

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/calendar/CalendarScreen.kt
@@ -2,7 +2,6 @@ package com.example.android_accountbook_13.presenter.calendar
 
 import android.annotation.SuppressLint
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
@@ -67,11 +66,11 @@ fun CalendarScreen(
         }
         Column(modifier = Modifier.fillMaxSize()) {
             Calendar(date, historyViewModel)
-            BothText(stringResource(id = R.string.income), moneyConverter(historyViewModel.incomeMoney.value), Green6)
+            BothText(stringResource(id = R.string.income), longToMoneyUnit(historyViewModel.incomeMoney.value), Green6)
             Divider(modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp), color = LightPurple)
-            BothText(stringResource(id = R.string.expense), "-"  + moneyConverter(historyViewModel.expenseMoney.value), Red)
+            BothText(stringResource(id = R.string.expense), "-"  + longToMoneyUnit(historyViewModel.expenseMoney.value), Red)
             Divider(modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp), color = LightPurple)
-            BothText(stringResource(id = R.string.total), moneyConverter(historyViewModel.incomeMoney.value - historyViewModel.expenseMoney.value), Purple)
+            BothText(stringResource(id = R.string.total), longToMoneyUnit(historyViewModel.incomeMoney.value - historyViewModel.expenseMoney.value), Purple)
             Divider(modifier = Modifier.padding(top = 8.dp), color = Purple)
         }
     }
@@ -98,7 +97,7 @@ fun Calendar(
                     if (it.color == Purple) {
                         if (viewModel.incomeMoneyOfDay.containsKey(it.day) && viewModel.incomeMoneyOfDay[it.day]!! > 0L)
                             Text(
-                                text = moneyConverter(viewModel.incomeMoneyOfDay[it.day]!!),
+                                text = longToMoneyUnit(viewModel.incomeMoneyOfDay[it.day]!!),
                                 style = MaterialTheme.typography.caption,
                                 color = Green6,
                                 maxLines = 1,
@@ -106,7 +105,7 @@ fun Calendar(
                             )
                         if (viewModel.expenseMoneyOfDay.containsKey(it.day) && viewModel.expenseMoneyOfDay[it.day]!! > 0L)
                             Text(
-                                text = "-${moneyConverter(viewModel.expenseMoneyOfDay[it.day]!!)}",
+                                text = "-${longToMoneyUnit(viewModel.expenseMoneyOfDay[it.day]!!)}",
                                 style = MaterialTheme.typography.caption,
                                 color = Red,
                                 maxLines = 1,
@@ -114,7 +113,7 @@ fun Calendar(
                             )
                         if ((viewModel.incomeMoneyOfDay.getOrDefault(it.day, 0L) - viewModel.expenseMoneyOfDay.getOrDefault(it.day, 0L)) != 0L)
                             Text(
-                                text = moneyConverter(
+                                text = longToMoneyUnit(
                                     (viewModel.incomeMoneyOfDay.getOrDefault(it.day, 0L) - viewModel.expenseMoneyOfDay.getOrDefault(
                                         it.day,
                                         0L

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/component/AccountBookItem.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/component/AccountBookItem.kt
@@ -23,7 +23,7 @@ import com.example.android_accountbook_13.ui.theme.Green6
 import com.example.android_accountbook_13.ui.theme.LightPurple
 import com.example.android_accountbook_13.ui.theme.Purple
 import com.example.android_accountbook_13.ui.theme.Red
-import com.example.android_accountbook_13.utils.moneyConverter
+import com.example.android_accountbook_13.utils.longToMoneyUnit
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -97,10 +97,10 @@ fun HistoryItemContent(
                 var text: String
                 if (accountBookItem.history.methodType == 1) {
                     color = Green6
-                    text = "${moneyConverter(accountBookItem.history.money)}원"
+                    text = "${longToMoneyUnit(accountBookItem.history.money)}원"
                 } else {
                     color = Red
-                    text = "-${moneyConverter(accountBookItem.history.money)}원"
+                    text = "-${longToMoneyUnit(accountBookItem.history.money)}원"
                 }
                 Text(
                     text = text,
@@ -140,11 +140,11 @@ fun ItemHeader(
             ) {
                 if (incomeChecked) {
                     HeaderText(stringResource(id = R.string.income))
-                    HeaderText(moneyConverter(income))
+                    HeaderText(longToMoneyUnit(income))
                 }
                 if (expenseChecked) {
                     HeaderText(stringResource(id = R.string.expense))
-                    HeaderText(moneyConverter(expense))
+                    HeaderText(longToMoneyUnit(expense))
                 }
             }
         }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/component/Button.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/component/Button.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.android_accountbook_13.R
 import com.example.android_accountbook_13.ui.theme.*
-import com.example.android_accountbook_13.utils.moneyConverter
+import com.example.android_accountbook_13.utils.longToMoneyUnit
 
 data class RadiusDP(
     val topStart: Dp = 14.dp,
@@ -203,7 +203,7 @@ private fun CheckedText(
         modifier = Modifier.size(24.dp)
     )
     Text(
-        text = "${title} ${moneyConverter(money)}",
+        text = "${title} ${longToMoneyUnit(money)}",
         modifier = modifier.padding(start = 8.dp),
         color = textColor,
         style = textStyle

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -143,7 +144,8 @@ fun AddingHistoryScreen(
                         if (textValue.isEmpty()) price = ""
                         else if ((textValue[textValue.lastIndex] in '0'..'9')) price = textValue
                     },
-                    keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number)
+                    keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+                    visualTransformation = { priceVisualTransformation(price) }
                 )
             }
 
@@ -308,7 +310,8 @@ private fun AddingHistoryTextField(
     onValueChange: (String) -> Unit,
     readOnly: Boolean = false,
     modifier: Modifier? = null,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None
 ) {
     TextField(
         value = text,
@@ -323,6 +326,7 @@ private fun AddingHistoryTextField(
         placeholder = { Text(text = placeHolder, color = LightPurple, fontWeight = FontWeight.Bold) },
         readOnly = readOnly,
         modifier = modifier ?: Modifier,
-        keyboardOptions = keyboardOptions
+        keyboardOptions = keyboardOptions,
+        visualTransformation = visualTransformation,
     )
 }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -1,5 +1,6 @@
 package com.example.android_accountbook_13.presenter.history
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -47,6 +48,11 @@ fun AddingHistoryScreen(
     historyViewModel: HistoryViewModel,
     settingViewModel: SettingViewModel
 ) {
+    BackHandler() {
+        historyViewModel.navItem = null
+        navHostController.popBackStack()
+    }
+
     val navItem = historyViewModel.navItem
     var date by rememberSaveable {
         mutableStateOf(
@@ -73,6 +79,7 @@ fun AddingHistoryScreen(
     val isHistorySuccess by historyViewModel.isSuccess
 
     if (isHistorySuccess.event is DataResponse.Success) {
+        historyViewModel.navItem = null
         historyViewModel.getAccountBookItems()
         isHistorySuccess(DataResponse.Empty)
         navHostController.popBackStack()
@@ -86,7 +93,10 @@ fun AddingHistoryScreen(
             TopAppBar(
                 title = "${stringResource(id = R.string.history)} ${if (navItem == null) stringResource(id = R.string.add) else stringResource(id = R.string.edit)}",
                 leftVectorResource = R.drawable.ic_back,
-                onLeftClick = { navHostController.popBackStack() }
+                onLeftClick = {
+                    historyViewModel.navItem = null
+                    navHostController.popBackStack()
+                }
             )
         },
         backgroundColor = OffWhite,

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/AddingHistoryScreen.kt
@@ -55,8 +55,8 @@ fun AddingHistoryScreen(
         )
     }
     var price by rememberSaveable { mutableStateOf(navItem?.history?.money?.toString() ?: "") }
-    var checkedMethod by remember { mutableStateOf(navItem?.method ?: Method(null, "")) }
-    var checkedCategory by remember { mutableStateOf(navItem?.category ?: Category(null, "", "", -1)) }
+    var checkedMethod by rememberSaveable { mutableStateOf(navItem?.method ?: Method(null, "")) }
+    var checkedCategory by rememberSaveable { mutableStateOf(navItem?.category ?: Category(null, "", "", -1)) }
     var content by rememberSaveable { mutableStateOf(navItem?.history?.name ?: "") }
 
     var methodExpanded by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -2,10 +2,7 @@ package com.example.android_accountbook_13.presenter.history
 
 import android.annotation.SuppressLint
 import android.util.Log
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
@@ -205,11 +202,12 @@ fun HistoryScreen(
                                 }
                             )
                         }
-
                         item {
                             Divider(color = Purple, modifier = Modifier.padding(top = 8.dp))
                         }
-
+                    }
+                    item{
+                        Spacer(modifier = Modifier.size(96.dp))
                     }
                 }
             } else {

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/HistoryScreen.kt
@@ -170,9 +170,7 @@ fun HistoryScreen(
                                 lastAccountBookItem,
                                 isEditMode = isEditMode,
                                 onClick = {
-                                    Log.d("Test",lastAccountBookItem.toString())
                                     historyViewModel.navItem = lastAccountBookItem
-                                    Log.d("Test",historyViewModel.navItem.toString())
                                     navHostController.navigate("addingHistory/${lastAccountBookItem.history.methodType}")
                                 },
                                 onCheckClick = { id ->

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/history/TextVisualTransformation.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/history/TextVisualTransformation.kt
@@ -1,0 +1,31 @@
+package com.example.android_accountbook_13.presenter.history
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import com.example.android_accountbook_13.utils.longToMoneyUnit
+
+fun priceVisualTransformation(text: String): TransformedText {
+    var out = if(text == "") "" else longToMoneyUnit(text.toLong())
+    val priceOffSetTranslator = object : OffsetMapping {
+        override fun originalToTransformed(offset: Int): Int {
+            val commas = out.count{ it == ','}
+            return offset + commas
+        }
+
+        override fun transformedToOriginal(offset: Int): Int {
+            val commas = out.count{ it == ','}
+            return when (offset) {
+                8, 7 -> offset - 2
+                6 -> if (commas == 1) 5 else 4
+                5 -> if (commas == 1) 4 else if (commas == 2) 3 else offset
+                4, 3 -> if (commas >= 1) offset - 1 else offset
+                2 -> if (commas == 2) 1 else offset
+                else -> offset
+            }
+        }
+
+    }
+    return TransformedText(AnnotatedString(out), priceOffSetTranslator)
+}

--- a/app/src/main/java/com/example/android_accountbook_13/presenter/statistic/StatisticScreen.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/presenter/statistic/StatisticScreen.kt
@@ -2,9 +2,6 @@ package com.example.android_accountbook_13.presenter.statistic
 
 import android.annotation.SuppressLint
 import android.graphics.Color
-import android.util.Log
-import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import android.widget.LinearLayout
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -19,7 +16,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import com.example.android_accountbook_13.R
-import com.example.android_accountbook_13.data.dto.Category
 import com.example.android_accountbook_13.presenter.calendar.BothText
 import com.example.android_accountbook_13.presenter.component.Category
 import com.example.android_accountbook_13.presenter.component.TopAppBar
@@ -29,13 +25,11 @@ import com.example.android_accountbook_13.ui.theme.LightPurple
 import com.example.android_accountbook_13.ui.theme.Purple
 import com.example.android_accountbook_13.ui.theme.Red
 import com.example.android_accountbook_13.utils.*
-import com.example.android_accountbook_13.utils.Date
 import com.github.mikephil.charting.animation.Easing
 import com.github.mikephil.charting.charts.PieChart
 import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
-import java.util.*
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
@@ -74,7 +68,7 @@ fun StatisticScreen(
 
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
-                BothText(leftText = stringResource(id = R.string.total_payment_of_month), rightText = moneyConverter(totalMoney), textColor = Red)
+                BothText(leftText = stringResource(id = R.string.total_payment_of_month), rightText = longToMoneyUnit(totalMoney), textColor = Red)
                 Divider(color = Purple, modifier = Modifier.padding(top = 8.dp))
             }
             item{
@@ -135,7 +129,7 @@ fun StatisticScreen(
                         backgroundColor = androidx.compose.ui.graphics.Color(Color.parseColor(pair.second.color)),
                         modifier = Modifier.padding(top = 10.dp)
                     )
-                    BothText(leftText = moneyConverter(pair.first), rightText = "${pair.first * 100 / totalMoney}%", textColor = Purple)
+                    BothText(leftText = longToMoneyUnit(pair.first), rightText = "${pair.first * 100 / totalMoney}%", textColor = Purple)
                 }
                 Divider(Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp), color = LightPurple)
             }

--- a/app/src/main/java/com/example/android_accountbook_13/utils/MoneyConverter.kt
+++ b/app/src/main/java/com/example/android_accountbook_13/utils/MoneyConverter.kt
@@ -1,6 +1,6 @@
 package com.example.android_accountbook_13.utils
 
-fun moneyConverter(money: Long) : String {
+fun longToMoneyUnit(money: Long) : String {
     val moneyString = StringBuilder(money.toString()).reverse()
     if(money < 0) moneyString.deleteCharAt(moneyString.lastIndex)
     val count = (moneyString.length - 1) / 3
@@ -11,4 +11,8 @@ fun moneyConverter(money: Long) : String {
         "-${moneyString.reverse()}"
     else
         moneyString.reverse().toString()
+}
+
+fun moneyUnitToLong(money: String): Long {
+    return money.replace(",","").toLong()
 }


### PR DESCRIPTION
## 개요

- 이슈 번호: #38  
- 내용: 
  - Fab 버튼이 아이템을 가리는 오류를 수정한다.
  - 내역 등록 탭에서 내역을 등록하러 화면을 벗어나도 입력 값들이 초기화 되지 않도록한다.
  - 달력에서 현재 날을 표시한다.

## 작업사항

- 아이템 마지막에 Spacer를 주어서 공간 확보
- 입력 값들을 모두 rememberSaveable로 변경 (객체의 경우 Parcelize 하여 저장)
- 금액을 입력할 때 , 표시 (VisualTransformation) 사용